### PR TITLE
Scale Levels, Naming Changes, & Trimming Strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Read .sav files (SPSS, PSPP) in a browser or in node.js",
   "main": "./dist/index.js",
   "types": "./dist/index.js",
-  "keywords": ["sav", "spss"],
+  "keywords": [
+    "sav",
+    "spss"
+  ],
   "scripts": {
     "build": "webpack"
   },
@@ -12,7 +15,9 @@
     "type": "git",
     "url": "git+https://github.com/mhermher/savvy.git"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "author": "Mher Alaverdyan",
   "license": "BSD-2-Clause",
   "bugs": {
@@ -27,6 +32,12 @@
     "ts-loader": "^8.0.4",
     "tslint": "^6.1.3",
     "typescript": "^4.0.3",
+    "webpack-cli": "^4.5.0",
     "webpack-node-externals": "^2.5.2"
+  },
+  "dependencies": {
+    "typedoc": "^0.20.28",
+    "typedoc-webpack-plugin": "^1.1.4",
+    "webpack": "^5.24.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsavvy",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Read .sav files (SPSS, PSPP) in a browser or in node.js",
   "main": "./dist/index.js",
   "types": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,11 @@
     "babel-loader": "^8.1.0",
     "ts-loader": "^8.0.4",
     "tslint": "^6.1.3",
+    "typedoc": "^0.20.32",
+    "typedoc-webpack-plugin": "^1.1.4",
     "typescript": "^4.0.3",
+    "webpack": "^5.26.0",
     "webpack-cli": "^4.5.0",
     "webpack-node-externals": "^2.5.2"
-  },
-  "dependencies": {
-    "typedoc": "^0.20.28",
-    "typedoc-webpack-plugin": "^1.1.4",
-    "webpack": "^5.24.3"
   }
 }

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -298,6 +298,9 @@ export class Savvy implements DataSet {
     public get n() : number {
         return(this.cases);
     }
+    public get keys() : Array<string> {
+        return(Array.from(this.fields.keys()));
+    }
     /**
      * A map of of unique column keys to variable names
      */

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -228,7 +228,6 @@ export class Savvy implements DataSet {
     constructor(parsed : Parsed) {
         this.cases = parsed.meta.cases;
         this._names = parsed.internal.names;
-        this._labels = parsed.internal.labels;
         this.data = parsed.rows;
         this._levels = new Map(
             parsed.headers.map(header => [header.name, new Map()])

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -220,6 +220,7 @@ export class Savvy implements DataSet {
     private _names : Map<string, string>;
     private _labels : Map<string, string>;
     private _levels : Map<string, Map<number, string>>;
+    private _missings : Map<string, Set<number | string>>;
     /**
      *
      * @param parsed a {@link Parsed} object generated with a {@link SavParser}
@@ -243,6 +244,7 @@ export class Savvy implements DataSet {
         this.fields = new Map();
         this.overflows = new Map();
         this._labels = new Map();
+        this._missings = new Map();
         let j : number = 0;
         for (let i = 0; i < parsed.headers.length; i++){
             j = i;
@@ -269,6 +271,7 @@ export class Savvy implements DataSet {
                         new Set(header.missing.strings)
                     )
                 );
+                this._missings.set(header.name, new Set(header.missing.strings));
             } else {
                 if (this._levels.get(header.name)?.size) {
                     this.fields.set(
@@ -293,6 +296,7 @@ export class Savvy implements DataSet {
                         )
                     )
                 }
+                this._missings.set(header.name, new Set(header.missing.codes));
             }
         }
         parsed.headers.reduce((left, right) => {
@@ -353,6 +357,18 @@ export class Savvy implements DataSet {
         this._levels = new Map([
             ...this._levels,
             ...levels
+        ]);
+    }
+    /**
+     * A map of of unique column keys to missing values
+     */
+    public get missings() : Map<string, Set<number | string>> {
+        return(new Map([...this._missings]));
+    }
+    public set missings(missings : Map<string, Set<number | string>>) {
+        this._missings = new Map([
+            ...this._missings,
+            ...missings
         ]);
     }
     public row(index : number) : Row {

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -234,7 +234,7 @@ export class Savvy implements DataSet {
         );
         parsed.internal.levels.forEach(
             entry => entry.indices.forEach(
-                index => this._levels.set(
+                index => (index <= parsed.headers.length) && this._levels.set(
                     parsed.headers[index - 1].name,
                     entry.map
                 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ class DataReader {
         return(
             new DataView(this.feeder.next(8)).getFloat64(
                 0,
-                this.schema.internal.integer.endianness == 2
+                this.schema.internal.integer.endianness === 2
             )
         )
     }
@@ -507,7 +507,6 @@ export class SavParser {
             display : partial.display ?? [],
             documents : partial.documents ?? [],
             names : partial.names ?? new Map(),
-            labels : partial.labels ?? new Map(),
             longs : partial.longs ?? new Map(),
             levels : partial.levels ?? [],
             extra : partial.extra ?? [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,7 @@ export class SavParser {
         const icount = view.getInt32(4, true);
         if (magic !== 4){
             throw new Error(
-                'Labels read error. ' +
+                'Levels read error. ' +
                 'Magic value Expected: 4 ' +
                 'Actual: ' + magic
             )
@@ -343,8 +343,8 @@ export class SavParser {
             )
         );
     }
-    private readLabels(feeder : Feeder, size : number) : Map<string, string> {
-        this.log.push('Labels at ' + feeder.position());
+    private readNames(feeder : Feeder, size : number) : Map<string, string> {
+        this.log.push('Names at ' + feeder.position());
         const raw = this.decoder.decode(feeder.next(size));
         return(
             new Map(
@@ -368,8 +368,8 @@ export class SavParser {
             )
         );
     }
-    private readLongLabels(feeder : Feeder, size : number) : ArrayBuffer {
-        this.log.push('Long Labels at ' + feeder.position());
+    private readLongNames(feeder : Feeder, size : number) : ArrayBuffer {
+        this.log.push('Long Names at ' + feeder.position());
         // need to figure out how this works
         return(feeder.next(size));
     }
@@ -451,9 +451,9 @@ export class SavParser {
                             break;
                         case 13:
                             this.log.push('Subcode 13');
-                            partial.labels = new Map([
-                                ...(partial.labels ?? []),
-                                ...this.readLabels(feeder, count * length)
+                            partial.names = new Map([
+                                ...(partial.names ?? []),
+                                ...this.readNames(feeder, count * length)
                             ]);
                             break;
                         case 14:
@@ -466,7 +466,7 @@ export class SavParser {
                         case 21:
                             this.log.push('Subcode 21');
                             partial.extra = (partial.extra ?? []).concat(
-                                this.readLongLabels(feeder, count * length)
+                                this.readLongNames(feeder, count * length)
                             );
                             break;
                         default:
@@ -506,6 +506,7 @@ export class SavParser {
             },
             display : partial.display ?? [],
             documents : partial.documents ?? [],
+            names : partial.names ?? new Map(),
             labels : partial.labels ?? new Map(),
             longs : partial.longs ?? new Map(),
             levels : partial.levels ?? [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,7 +257,7 @@ export class SavParser {
         });
     }
     private getLevel(feeder : Feeder) : [number, string] {
-        this.log.push('Factor level at ' + feeder.position());
+        this.log.push('Scale level at ' + feeder.position());
         const view = new DataView(feeder.next(9));
         const length = view.getInt8(8);
         const size = ((length + 1) % 8
@@ -266,7 +266,7 @@ export class SavParser {
         );
         return([
             view.getFloat64(0, true),
-            this.decoder.decode(feeder.next(size)).substring(0, length)
+            this.decoder.decode(feeder.next(size)).substring(0, length).trim()
         ]);
     }
     private readScale(feeder : Feeder) : Scale {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,6 @@ export interface Internal {
     display : Array<Display>,
     documents : Array<Array<string>>,
     names : Map<string, string>,
-    labels : Map<string, string>,
     levels : Array<Scale>,
     longs : Map<string, number>,
     extra : Array<ArrayBuffer>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface Header {
     /** A unique identifier for the column */
     name : string,
     /** A label for the column name */
-    description : string,
+    label : string,
     /** missingness indicators for the column */
     missing : {
         /** a set of values that represent a missing number */
@@ -51,11 +51,11 @@ export interface Header {
     }
 }
 
-/** Factor labels */
-export interface Factor {
+/** Scale levels and labels */
+export interface Scale {
     /** key-value pairs for underlying numeric value and string label */
     map : Map<number, string>,
-    /** a set of column indices which these factor labels apply to */
+    /** a set of column indices which these scale labels apply to */
     indices : Set<number>
 }
 
@@ -87,7 +87,7 @@ export interface Internal {
     documents : Array<Array<string>>,
     labels : Map<string, string>,
     longs : Map<string, number>,
-    factors : Array<Factor>,
+    levels : Array<Scale>,
     extra : Array<ArrayBuffer>,
     unrecognized : Array<[number, Array<ArrayBuffer>]>,
     finished : number

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,9 +85,10 @@ export interface Internal {
     },
     display : Array<Display>,
     documents : Array<Array<string>>,
+    names : Map<string, string>,
     labels : Map<string, string>,
-    longs : Map<string, number>,
     levels : Array<Scale>,
+    longs : Map<string, number>,
     extra : Array<ArrayBuffer>,
     unrecognized : Array<[number, Array<ArrayBuffer>]>,
     finished : number


### PR DESCRIPTION
- To more closely reflect IBM SPSS naming conventions:
1. rename `description` to `label` (these are called "variable labels" in SPSS)
2. rename `factors` to `levels` (these are called "value labels" in SPSS but that's confusing, so I went with `levels` which is close-ish)
- Made `levels` public (`factors` were previously private)
- Trim variable names.
- Trim variable labels.
- Trim scale levels.
- Added dependencies required to build.